### PR TITLE
Fix segfault issue #1

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -156,8 +156,9 @@ void add_config_item(struct config *con, signed char short_name, char *long_name
     c->long_option.has_arg = (dst_type != CONFIG_BOOL);
     c->long_option.flag = NULL;
     c->long_option.val = c->short_name;
-    
-    *c->dst = NULL;
+
+    // Fix segfault issue #1
+    //*c->dst = NULL;
 
     con->count++;
     


### PR DESCRIPTION
`dst` variable is set to `NULL` after initialization of settings but in some circonstance, the variable is still used (`log_level`, `format`,...) and was causing the segfault.
